### PR TITLE
[#4] 구독 기능 추가

### DIFF
--- a/subsclife/src/main/java/com/fthon/subsclife/common/Constants.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/common/Constants.java
@@ -1,0 +1,8 @@
+package com.fthon.subsclife.common;
+
+public class Constants {
+
+    public static final long TASK_SUBSCRIBER_LIMIT = 20;
+    public static final long USER_SUBSCRIBE_LIMIT = 10;
+
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/controller/UserController.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/controller/UserController.java
@@ -4,14 +4,12 @@ package com.fthon.subsclife.controller;
 import com.fthon.subsclife.dto.UserResponseDto;
 import com.fthon.subsclife.dto.mapper.UserMapper;
 import com.fthon.subsclife.entity.User;
+import com.fthon.subsclife.service.SubscriptionFacade;
 import com.fthon.subsclife.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -20,13 +18,25 @@ public class UserController {
 
     private final UserService userService;
 
+    private final SubscriptionFacade subscriptionFacade;
+
     private final UserMapper userMapper;
 
     @PostMapping("/login")
-    public ResponseEntity<UserResponseDto> login(@RequestHeader("user_id") Long userId) {
+    public ResponseEntity<UserResponseDto> login(@RequestHeader("user-id") Long userId) {
         User user = userService.findUserById(userId);
 
         return new ResponseEntity<>(userMapper.toResponseDto(user), HttpStatus.OK);
+    }
+
+    @PostMapping("/subscribe")
+    public ResponseEntity<HttpStatus> subscribe(
+            @RequestHeader("user-id") Long userId,
+            @RequestParam("task_id") Long taskId) {
+
+        subscriptionFacade.subscribe(taskId, userId);
+
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/entity/Subscribe.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/entity/Subscribe.java
@@ -1,0 +1,35 @@
+package com.fthon.subsclife.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@NoArgsConstructor
+@Getter
+@Entity
+@Table(name = "SUBSCRIBE")
+public class Subscribe {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "TASK_ID")
+    private Task task;
+
+    @Builder
+    public Subscribe(User user, Task task) {
+        this.user = user;
+        this.task = task;
+    }
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/entity/Task.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/entity/Task.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @NoArgsConstructor
 @Getter
 @Entity
@@ -28,12 +31,19 @@ public class Task {
     @Embedded
     private Period period;
 
+    @OneToMany(mappedBy = "task")
+    private List<Subscribe> subscribes = new ArrayList<>();
+
     @Builder
     public Task(String title, String simpleInfo, String detail, Period period) {
         this.title = title;
         this.simpleInfo = simpleInfo;
         this.detail = detail;
         this.period = period;
+    }
+
+    public long getSubscriberCount() {
+        return subscribes.size();
     }
 
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/entity/User.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/entity/User.java
@@ -1,9 +1,18 @@
 package com.fthon.subsclife.entity;
 
+import com.fthon.subsclife.exception.TaskSubscriptionClosedException;
+import com.fthon.subsclife.exception.UserSubscriptionOverflowException;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.fthon.subsclife.common.Constants.TASK_SUBSCRIBER_LIMIT;
+import static com.fthon.subsclife.common.Constants.USER_SUBSCRIBE_LIMIT;
 
 
 @NoArgsConstructor
@@ -22,9 +31,41 @@ public class User {
     @Column(name = "NICKNAME")
     private String nickname;
 
+    @OneToMany(mappedBy = "user")
+    private List<Subscribe> subscribes = new ArrayList<>();
+
     @Builder
     public User(String name, String nickname) {
         this.name = name;
         this.nickname = nickname;
+    }
+
+
+    public long getSubscribeCount() {
+        // 이미 만료된 것들은 개수에서 제외해야 함
+        return subscribes.stream().filter(subscribe -> {
+                        // 태스크의 마감 기한이 now()를 지났을 경우를 제외한 개수
+                        return subscribe.getTask()
+                                .getPeriod()
+                                .getEndDate()
+                                .isAfter(LocalDateTime.now());
+                }).count();
+    }
+
+    public Subscribe subscribe(Task task) {
+        // 태스크 구독자 수가 구독자 제한보다 많으면 안됨
+        if (task.getSubscriberCount() >= TASK_SUBSCRIBER_LIMIT) {
+            throw new TaskSubscriptionClosedException("구독 마감된 태스크입니다.");
+        }
+
+        // 사용자 구독 수가 구독 제한보다 많으면 안됨
+        if (getSubscribeCount() >= USER_SUBSCRIBE_LIMIT) {
+            throw new UserSubscriptionOverflowException("구독 개수가 너무 많습니다.");
+        }
+
+        return Subscribe.builder()
+                .user(this)
+                .task(task)
+                .build();
     }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/exception/TaskSubscriptionClosedException.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/exception/TaskSubscriptionClosedException.java
@@ -1,0 +1,16 @@
+package com.fthon.subsclife.exception;
+
+
+/**
+ * 태스크에 대한 구독자 수가 초과됐을 때 발생
+ */
+public class TaskSubscriptionClosedException extends RuntimeException {
+
+    public TaskSubscriptionClosedException() {
+        super();
+    }
+
+    public TaskSubscriptionClosedException(String message) {
+        super(message);
+    }
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/exception/UserSubscriptionOverflowException.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/exception/UserSubscriptionOverflowException.java
@@ -1,0 +1,15 @@
+package com.fthon.subsclife.exception;
+
+
+/**
+ * 사용자의 구독이 최대치에 도달했을 때
+ */
+public class UserSubscriptionOverflowException extends RuntimeException {
+    public UserSubscriptionOverflowException() {
+        super();
+    }
+
+    public UserSubscriptionOverflowException(String message) {
+        super(message);
+    }
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/exception/advice/GlobalExceptionAdvice.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/exception/advice/GlobalExceptionAdvice.java
@@ -1,6 +1,8 @@
 package com.fthon.subsclife.exception.advice;
 
 import com.fthon.subsclife.exception.ErrorInfo;
+import com.fthon.subsclife.exception.TaskSubscriptionClosedException;
+import com.fthon.subsclife.exception.UserSubscriptionOverflowException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -14,5 +16,15 @@ public class GlobalExceptionAdvice {
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<ErrorInfo> NoSuchElementExceptionHandler(NoSuchElementException e) {
         return new ResponseEntity<>(new ErrorInfo(e), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(TaskSubscriptionClosedException.class)
+    public ResponseEntity<ErrorInfo> TaskSubscriptionClosedExceptionHandler(TaskSubscriptionClosedException e) {
+        return new ResponseEntity<>(new ErrorInfo(e), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(UserSubscriptionOverflowException.class)
+    public ResponseEntity<ErrorInfo> UserSubscriptionOverflowExceptionHandler(UserSubscriptionOverflowException e) {
+        return new ResponseEntity<>(new ErrorInfo(e), HttpStatus.CONFLICT);
     }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/SubscribeRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/SubscribeRepository.java
@@ -1,0 +1,9 @@
+package com.fthon.subsclife.repository;
+
+import com.fthon.subsclife.entity.Subscribe;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
@@ -2,9 +2,16 @@ package com.fthon.subsclife.repository;
 
 import com.fthon.subsclife.entity.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 
 @Repository
 public interface TaskRepository extends JpaRepository<Task, Long> {
+
+    @Query("SELECT t FROM Task t LEFT JOIN FETCH t.subscribes WHERE t.id = :taskId")
+    Optional<Task> findByIdWithSubscribes(@Param("taskId") Long taskId);
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/UserRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/UserRepository.java
@@ -2,8 +2,15 @@ package com.fthon.subsclife.repository;
 
 import com.fthon.subsclife.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.subscribes WHERE u.id = :userId")
+    Optional<User> findByIdWithSubscribes(@Param("userId") Long userId);
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/service/SubscribeService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/SubscribeService.java
@@ -1,0 +1,32 @@
+package com.fthon.subsclife.service;
+
+
+import com.fthon.subsclife.entity.Subscribe;
+import com.fthon.subsclife.entity.Task;
+import com.fthon.subsclife.entity.User;
+import com.fthon.subsclife.repository.SubscribeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class SubscribeService {
+
+    private final SubscribeRepository subscribeRepository;
+
+    private final UserService userService;
+
+    private final TaskService taskService;
+
+
+    @Transactional
+    public void subscribeTask(Long userId, Long taskId) {
+        User user = userService.findUserByIdWithSubscribes(userId);
+        Task task = taskService.findTaskByIdWithSubscribes(taskId);
+
+        Subscribe subscribe = user.subscribe(task);
+        subscribeRepository.save(subscribe);
+    }
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/service/SubscriptionFacade.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/SubscriptionFacade.java
@@ -1,0 +1,16 @@
+package com.fthon.subsclife.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionFacade {
+
+    private final SubscribeService subscribeService;
+
+    public synchronized void subscribe(Long userId, Long taskId) {
+        subscribeService.subscribeTask(userId, taskId);
+    }
+
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
+
 @Service
 @RequiredArgsConstructor
 public class TaskService {
@@ -22,5 +24,17 @@ public class TaskService {
         Task task = taskMapper.toEntity(dto);
 
         taskRepository.save(task);
+    }
+
+    @Transactional(readOnly = true)
+    public Task findTaskById(Long taskId) {
+        return taskRepository.findById(taskId)
+                .orElseThrow(() -> new NoSuchElementException("찾으려는 태스크가 없습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public Task findTaskByIdWithSubscribes(Long taskId) {
+        return taskRepository.findById(taskId)
+                .orElseThrow(() -> new NoSuchElementException("찾으려는 태스크가 없습니다."));
     }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/service/UserService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/UserService.java
@@ -1,6 +1,5 @@
 package com.fthon.subsclife.service;
 
-
 import com.fthon.subsclife.entity.User;
 import com.fthon.subsclife.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,4 +20,9 @@ public class UserService {
                 .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
     }
 
+    @Transactional(readOnly = true)
+    public User findUserByIdWithSubscribes(Long id) {
+        return userRepository.findByIdWithSubscribes(id)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+    }
 }

--- a/subsclife/src/test/java/com/fthon/subsclife/controller/UserControllerTest.java
+++ b/subsclife/src/test/java/com/fthon/subsclife/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package com.fthon.subsclife.controller;
 import com.fthon.subsclife.dto.mapper.UserMapper;
 import com.fthon.subsclife.entity.User;
 import com.fthon.subsclife.exception.advice.GlobalExceptionAdvice;
+import com.fthon.subsclife.service.SubscriptionFacade;
 import com.fthon.subsclife.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -34,6 +35,9 @@ class UserControllerTest {
     private UserService userService;
 
     @MockBean
+    private SubscriptionFacade subscriptionFacade;
+
+    @MockBean
     private UserMapper userMapper;
 
     @Nested
@@ -55,7 +59,7 @@ class UserControllerTest {
 
                 //when & then
                 mockMvc.perform(post("/api/v1/users/login")
-                                .header("user_id", userId)
+                                .header("user-id", userId)
                                 .contentType(MediaType.APPLICATION_JSON))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.name").value(USER_NAME))
@@ -71,7 +75,7 @@ class UserControllerTest {
 
                 //when & then
                 mockMvc.perform(post("/api/v1/users/login")
-                            .header("user_id", userId)
+                            .header("user-id", userId)
                             .contentType(MediaType.APPLICATION_JSON))
                         .andExpect(status().isNotFound());
             }

--- a/subsclife/src/test/java/com/fthon/subsclife/domain/SubscriptionTest.java
+++ b/subsclife/src/test/java/com/fthon/subsclife/domain/SubscriptionTest.java
@@ -1,0 +1,93 @@
+package com.fthon.subsclife.domain;
+
+import com.fthon.subsclife.entity.Period;
+import com.fthon.subsclife.entity.Subscribe;
+import com.fthon.subsclife.entity.Task;
+import com.fthon.subsclife.entity.User;
+import com.fthon.subsclife.exception.TaskSubscriptionClosedException;
+import com.fthon.subsclife.exception.UserSubscriptionOverflowException;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.fthon.subsclife.common.Constants.TASK_SUBSCRIBER_LIMIT;
+import static com.fthon.subsclife.common.Constants.USER_SUBSCRIBE_LIMIT;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SubscriptionTest {
+
+    @InjectMocks
+    private User user;
+
+    @Mock
+    private Task task;
+
+    @Mock
+    private Subscribe subscribe;
+
+
+    @Nested
+    @DisplayName("태스크 구독을 시도할 때")
+    class Request_Subscribe_Task {
+
+        @Nested
+        @DisplayName("태스크의 구독자 수가 제한보다 많다면")
+        class Subscriber_Over_Limit {
+
+            @BeforeEach
+            void setUp() {
+                //given
+                when(task.getSubscriberCount()).thenReturn(TASK_SUBSCRIBER_LIMIT + 1); // 제한을 초과하는 값 설정
+            }
+
+            @Test
+            @DisplayName("예외가 발생한다.")
+            void throws_task_over_exception() {
+                //when & then
+                assertThrows(TaskSubscriptionClosedException.class, () -> user.subscribe(task));
+            }
+        }
+
+        @Nested
+        @DisplayName("사용자의 구독 수가 제한보다 많다면")
+        class Subscribe_Over_Limit {
+
+            @BeforeEach
+            void setUp() {
+                //given
+                when(task.getPeriod()).thenReturn(
+                        Period.builder()
+                                .startDate(LocalDateTime.now())
+                                .endDate(LocalDateTime.now().plusDays(1))
+                                .build()
+                );
+
+                List<Subscribe> subscribes = new ArrayList<>();
+                for (int i = 0; i < USER_SUBSCRIBE_LIMIT + 1; i++) {
+                    Subscribe validSubscribe = Subscribe.builder()
+                            .user(user)
+                            .task(task)
+                            .build();
+                    subscribes.add(validSubscribe);
+                }
+                user.getSubscribes().addAll(subscribes); // 구독 리스트에 생성된 구독 추가
+            }
+
+            @Test
+            @DisplayName("예외가 발생한다.")
+            void throws_subscribe_over_exception() {
+                //when & then
+                assertThrows(UserSubscriptionOverflowException.class, () -> user.subscribe(task));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#4 태스크 구독 기능 구현

## 📝작업 내용
- 태스크에 대해 구독을 진행하는 기능을 개발하였습니다.
- 각 태스크는 총 20명의 구독자를 가질 수 있습니다.
- 각 사용자는 10개의 태스크를 구독할 수 있습니다.
    - 이 경우, 시간이 마감되어 회고 대기중인 구독은 개수에 포함되지 않습니다.
