### PR TITLE
[#11] 구독 취소 기능 구현

### DIFF
--- a/subsclife/src/main/java/com/fthon/subsclife/controller/UserController.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/controller/UserController.java
@@ -39,4 +39,16 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/unsubscribe")
+    public ResponseEntity<HttpStatus> unsubscribe(
+            @RequestHeader("user-id") Long userId,
+            @RequestParam("task_id") Long taskId) {
+
+        subscriptionFacade.unsubscribe(taskId, userId);
+
+        return ResponseEntity.ok().build();
+    }
+
+
+
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/entity/User.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/entity/User.java
@@ -10,9 +10,10 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
-import static com.fthon.subsclife.common.Constants.TASK_SUBSCRIBER_LIMIT;
-import static com.fthon.subsclife.common.Constants.USER_SUBSCRIBE_LIMIT;
+import static com.fthon.subsclife.common.Constants.*;
 
 
 @NoArgsConstructor
@@ -53,6 +54,20 @@ public class User {
     }
 
     public Subscribe subscribe(Task task) {
+        validateSubscribe(task);
+
+        return Subscribe.builder()
+                .user(this)
+                .task(task)
+                .build();
+    }
+
+    private void validateSubscribe(Task task) {
+        // 이미 구독했다면 안됨
+        findSubscribedTask(task.getId()).ifPresent(s -> {
+            throw new UserSubscriptionOverflowException("이미 구독한 태스크입니다.");
+        });
+
         // 태스크 구독자 수가 구독자 제한보다 많으면 안됨
         if (task.getSubscriberCount() >= TASK_SUBSCRIBER_LIMIT) {
             throw new TaskSubscriptionClosedException("구독 마감된 태스크입니다.");
@@ -62,10 +77,25 @@ public class User {
         if (getSubscribeCount() >= USER_SUBSCRIBE_LIMIT) {
             throw new UserSubscriptionOverflowException("구독 개수가 너무 많습니다.");
         }
+    }
 
-        return Subscribe.builder()
-                .user(this)
-                .task(task)
-                .build();
+    public void removeSubscribe(Subscribe subscribe) {
+        subscribes.remove(subscribe);
+        subscribe.setUser(null);
+    }
+
+    public Subscribe unsubscribe(Long taskId) {
+        Optional<Subscribe> subscribe = findSubscribedTask(taskId);
+
+        subscribe.ifPresent(this::removeSubscribe);
+
+        return subscribe.orElseThrow(() -> new NoSuchElementException("구독이 존재하지 않습니다."));
+    }
+
+    private Optional<Subscribe> findSubscribedTask(Long taskId) {
+        Optional<Subscribe> subscribe = subscribes.stream().filter(s -> {
+            return s.getTask().getId().equals(taskId);
+        }).findFirst();
+        return subscribe;
     }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/entity/User.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/entity/User.java
@@ -93,9 +93,8 @@ public class User {
     }
 
     private Optional<Subscribe> findSubscribedTask(Long taskId) {
-        Optional<Subscribe> subscribe = subscribes.stream().filter(s -> {
-            return s.getTask().getId().equals(taskId);
-        }).findFirst();
-        return subscribe;
+        return subscribes
+                .stream()
+                .filter(s -> s.getTask().getId().equals(taskId)).findFirst();
     }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/service/SubscribeService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/SubscribeService.java
@@ -29,4 +29,12 @@ public class SubscribeService {
         Subscribe subscribe = user.subscribe(task);
         subscribeRepository.save(subscribe);
     }
+
+    @Transactional
+    public void unsubscribeTask(Long userId, Long taskId) {
+        User user = userService.findUserByIdWithSubscribes(userId);
+
+        Subscribe subscribe = user.unsubscribe(taskId);
+        subscribeRepository.delete(subscribe);
+    }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/service/SubscriptionFacade.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/SubscriptionFacade.java
@@ -13,4 +13,8 @@ public class SubscriptionFacade {
         subscribeService.subscribeTask(userId, taskId);
     }
 
+    public void unsubscribe(Long userId, Long taskId) {
+        subscribeService.unsubscribeTask(taskId, userId);
+    }
+
 }

--- a/subsclife/src/test/java/com/fthon/subsclife/domain/SubscriptionTest.java
+++ b/subsclife/src/test/java/com/fthon/subsclife/domain/SubscriptionTest.java
@@ -64,13 +64,6 @@ public class SubscriptionTest {
             @BeforeEach
             void setUp() {
                 //given
-                when(task.getPeriod()).thenReturn(
-                        Period.builder()
-                                .startDate(LocalDateTime.now())
-                                .endDate(LocalDateTime.now().plusDays(1))
-                                .build()
-                );
-
                 List<Subscribe> subscribes = new ArrayList<>();
                 for (int i = 0; i < USER_SUBSCRIBE_LIMIT + 1; i++) {
                     Subscribe validSubscribe = Subscribe.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

#11 구독 취소 기능 구현

## 📝작업 내용
- 태스크 아이디를 입력받아 구독을 취소합니다.
- 구독 시 "동일 태스크 구독" 시나리오에 대한 예외 처리를 추가하였습니다.