### PR TITLE
[#12] 상세 태스크 조회 기능 구현

### DIFF
--- a/subsclife/src/main/java/com/fthon/subsclife/controller/TaskController.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/controller/TaskController.java
@@ -2,19 +2,19 @@ package com.fthon.subsclife.controller;
 
 
 import com.fthon.subsclife.dto.TaskDto;
+import com.fthon.subsclife.exception.ErrorInfo;
 import com.fthon.subsclife.service.TaskService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/tasks")
@@ -32,4 +32,22 @@ public class TaskController {
 
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/{taskId}")
+    @Operation(summary = "태스크 단건 세부 조회", description = "단일 태스크의 세부 정보 조회 시 사용되는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "태스크 조회 성공",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = TaskDto.DetailResponse.class))),
+            @ApiResponse(responseCode = "401", description = "user-id가 없거나 잘못된 값이 전달되었음",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorInfo.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorInfo.class)))
+    })
+    public ResponseEntity<TaskDto.DetailResponse> getDetailTaskInfo(
+            @RequestHeader("user-id") Long userId,
+            @PathVariable("taskId") Long taskId) {
+
+        return new ResponseEntity<>(taskService.getTaskDetail(taskId), HttpStatus.OK);
+    }
+
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/TaskDto.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/TaskDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class TaskDto {
 
@@ -37,7 +38,33 @@ public class TaskDto {
             this.startDate = startDate;
             this.endDate = endDate;
         }
+    }
 
 
+    @NoArgsConstructor
+    @Getter
+    public static class DetailResponse {
+
+        private Long taskId;
+        private String title;
+        private String simpleInfo;
+        private String detail;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+        private List<UserDto.Response> subscribers;
+        private Boolean isSubscribed;
+
+        @Builder
+        public DetailResponse(Long taskId, String title, String simpleInfo, String detail, List<UserDto.Response> subscribers,
+                              LocalDateTime startDate, LocalDateTime endDate, Boolean isSubscribed) {
+            this.taskId = taskId;
+            this.title = title;
+            this.simpleInfo = simpleInfo;
+            this.detail = detail;
+            this.subscribers = subscribers;
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.isSubscribed = isSubscribed;
+        }
     }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/UserDto.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/UserDto.java
@@ -11,13 +11,13 @@ public class UserDto {
     @Getter
     @NoArgsConstructor
     public static class Response {
-        private Long id;
+        private Long userId;
         private String name;
         private String nickname;
 
         @Builder
-        public Response(Long id, String name, String nickname) {
-            this.id = id;
+        public Response(Long userId, String name, String nickname) {
+            this.userId = userId;
             this.name = name;
             this.nickname = nickname;
         }

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/TaskMapper.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/TaskMapper.java
@@ -3,10 +3,15 @@ package com.fthon.subsclife.dto.mapper;
 import com.fthon.subsclife.dto.TaskDto;
 import com.fthon.subsclife.entity.Period;
 import com.fthon.subsclife.entity.Task;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+
 @Component
+@RequiredArgsConstructor
 public class TaskMapper {
+
+    private final UserMapper userMapper;
 
     public Task toEntity(TaskDto.SaveRequest saveRequest) {
         return Task.builder()
@@ -18,6 +23,21 @@ public class TaskMapper {
                         .endDate(saveRequest.getEndDate())
                         .build()
                 )
+                .build();
+    }
+
+    public TaskDto.DetailResponse toDetailResponse(Task task, Long userId) {
+        return TaskDto.DetailResponse.builder()
+                .taskId(task.getId())
+                .title(task.getTitle())
+                .simpleInfo(task.getSimpleInfo())
+                .detail(task.getDetail())
+                .startDate(task.getPeriod().getStartDate())
+                .endDate(task.getPeriod().getEndDate())
+                .subscribers(
+                        task.getSubscribes().stream().map(t -> userMapper.toResponseDto(t.getUser())).toList()
+                )
+                .isSubscribed(task.isSubscribed(userId))
                 .build();
     }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/UserMapper.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/UserMapper.java
@@ -10,7 +10,7 @@ public class UserMapper {
 
     public UserDto.Response toResponseDto(User user) {
         return UserDto.Response.builder()
-                .id(user.getId())
+                .userId(user.getId())
                 .name(user.getName())
                 .nickname(user.getNickname())
                 .build();

--- a/subsclife/src/main/java/com/fthon/subsclife/entity/Task.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/entity/Task.java
@@ -46,4 +46,9 @@ public class Task {
         return subscribes.size();
     }
 
+    public boolean isSubscribed(Long userId) {
+        return subscribes.stream()
+                .anyMatch(s -> s.getUser().getId().equals(userId));
+    }
+
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
@@ -14,4 +14,10 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     @Query("SELECT t FROM Task t LEFT JOIN FETCH t.subscribes WHERE t.id = :taskId")
     Optional<Task> findByIdWithSubscribes(@Param("taskId") Long taskId);
+
+    @Query("SELECT t FROM Task t" +
+            " LEFT JOIN FETCH t.subscribes s" +
+            " JOIN FETCH s.user u" +
+            " WHERE t.id = :taskId")
+    Optional<Task> findByIdWithSubscribesAndUser(@Param("taskId") Long taskId);
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
@@ -3,6 +3,7 @@ package com.fthon.subsclife.service;
 
 import com.fthon.subsclife.dto.TaskDto;
 import com.fthon.subsclife.dto.mapper.TaskMapper;
+import com.fthon.subsclife.entity.Subscribe;
 import com.fthon.subsclife.entity.Task;
 import com.fthon.subsclife.repository.TaskRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,11 +20,21 @@ public class TaskService {
 
     private final TaskMapper taskMapper;
 
+    private final LoginService loginService;
+
     @Transactional
     public void saveTask(TaskDto.SaveRequest dto) {
         Task task = taskMapper.toEntity(dto);
 
         taskRepository.save(task);
+    }
+
+    @Transactional(readOnly = true)
+    public TaskDto.DetailResponse getTaskDetail(Long taskId) {
+        Task task = findTaskByIdWithSubscribesAndUser(taskId);
+        Long userId = loginService.getLoginUserId();
+
+        return taskMapper.toDetailResponse(task, userId);
     }
 
     @Transactional(readOnly = true)
@@ -34,7 +45,14 @@ public class TaskService {
 
     @Transactional(readOnly = true)
     public Task findTaskByIdWithSubscribes(Long taskId) {
-        return taskRepository.findById(taskId)
+        return taskRepository.findByIdWithSubscribes(taskId)
                 .orElseThrow(() -> new NoSuchElementException("찾으려는 태스크가 없습니다."));
     }
+
+    @Transactional(readOnly = true)
+    public Task findTaskByIdWithSubscribesAndUser(Long taskId) {
+        return taskRepository.findByIdWithSubscribesAndUser(taskId)
+                .orElseThrow(() -> new NoSuchElementException("찾으려는 태스크가 없습니다."));
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#12 TASK 조회 기능 구현

## 📝작업 내용
- 상세 태스크 페이지에서 사용될 데이터 조회 기능을 구현했습니다.
- (부가) 사용자 정보 응답 시 필드 명이 수정되었습니다.
    - `id` -> `userId`