### PR TITLE
[#12] 태스크 목록 조회 기능 구현

### DIFF
--- a/subsclife/src/main/java/com/fthon/subsclife/common/config/QuerydslConfig.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/common/config/QuerydslConfig.java
@@ -1,0 +1,16 @@
+package com.fthon.subsclife.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/controller/TaskController.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/controller/TaskController.java
@@ -1,6 +1,7 @@
 package com.fthon.subsclife.controller;
 
 
+import com.fthon.subsclife.dto.PagedItem;
 import com.fthon.subsclife.dto.TaskDto;
 import com.fthon.subsclife.exception.ErrorInfo;
 import com.fthon.subsclife.service.TaskService;
@@ -15,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/v1/tasks")
@@ -48,6 +51,41 @@ public class TaskController {
             @PathVariable("taskId") Long taskId) {
 
         return new ResponseEntity<>(taskService.getTaskDetail(taskId), HttpStatus.OK);
+    }
+
+    @GetMapping
+    @Operation(summary = "태스크 목록 조회", description = "태스크 목록 조회 시 사용되는 API")
+    public ResponseEntity<PagedItem<TaskDto.ListResponse>> searchTaskList(
+                @RequestHeader("user-id") Long userId,
+                @RequestParam(name = "task_id", required = false) Long taskId,
+                @RequestParam(name = "start_date", required = false) LocalDateTime startDate,
+                @RequestParam(name = "end_date", required = false) LocalDateTime endDate,
+                @RequestParam(name = "page_size", required = false, defaultValue = "10") Long pageSize,
+                @RequestParam(name = "start_from", required = false) LocalDateTime startFrom,
+                @RequestParam(name = "end_to", required = false) LocalDateTime endTo,
+                @RequestParam(name = "keyword", required = false) String keyword) {
+
+        TaskDto.Cursor cursor = getCursor(taskId, startDate, endDate);
+        TaskDto.SearchCondition cond = getSearchCondition(pageSize, startFrom, endTo, keyword);
+
+        return new ResponseEntity<>(taskService.getTaskList(cursor, cond), HttpStatus.OK);
+    }
+
+    private static TaskDto.SearchCondition getSearchCondition(Long pageSize, LocalDateTime startFrom, LocalDateTime endTo, String keyword) {
+        return TaskDto.SearchCondition.builder()
+                .pageSize(pageSize)
+                .startFrom(startFrom)
+                .endTo(endTo)
+                .keyword(keyword)
+                .build();
+    }
+
+    private static TaskDto.Cursor getCursor(Long taskId, LocalDateTime startDate, LocalDateTime endDate) {
+        return TaskDto.Cursor.builder()
+                .taskId(taskId)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
     }
 
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/PagedItem.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/PagedItem.java
@@ -1,0 +1,20 @@
+package com.fthon.subsclife.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PagedItem<T> {
+
+    private List<T> items;
+
+    // 다음 페이지가 존재하는지 여부
+    private Boolean hasNext;
+
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/TaskDto.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/TaskDto.java
@@ -43,6 +43,40 @@ public class TaskDto {
 
     @NoArgsConstructor
     @Getter
+    public static class Cursor {
+        private Long taskId;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+
+        @Builder
+        public Cursor(Long taskId, LocalDateTime startDate, LocalDateTime endDate) {
+            this.taskId = taskId;
+            this.startDate = startDate;
+            this.endDate = endDate;
+        }
+    }
+
+
+    @NoArgsConstructor
+    @Getter
+    public static class SearchCondition {
+        private LocalDateTime startFrom;
+        private LocalDateTime endTo;
+        private String keyword;
+        private Long pageSize;
+
+        @Builder
+        public SearchCondition(LocalDateTime startFrom, LocalDateTime endTo, String keyword, Long pageSize) {
+            this.startFrom = startFrom;
+            this.endTo = endTo;
+            this.keyword = keyword;
+            this.pageSize = pageSize;
+        }
+    }
+
+
+    @NoArgsConstructor
+    @Getter
     public static class DetailResponse {
 
         private Long taskId;
@@ -67,4 +101,29 @@ public class TaskDto {
             this.isSubscribed = isSubscribed;
         }
     }
+
+
+    @NoArgsConstructor
+    @Getter
+    public static class ListResponse {
+        private Long taskId;
+        private String title;
+        private String simpleInfo;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+        private Long subscriberCount;
+
+        @Builder
+        public ListResponse(Long taskId, String title, String simpleInfo,
+                            LocalDateTime startDate, LocalDateTime endDate, Long subscriberCount) {
+            this.taskId = taskId;
+            this.title = title;
+            this.simpleInfo = simpleInfo;
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.subscriberCount = subscriberCount;
+        }
+    }
+
+
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/TaskMapper.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/TaskMapper.java
@@ -40,4 +40,15 @@ public class TaskMapper {
                 .isSubscribed(task.isSubscribed(userId))
                 .build();
     }
+
+    public TaskDto.ListResponse toListResponse(Task task) {
+        return TaskDto.ListResponse.builder()
+                .taskId(task.getId())
+                .title(task.getTitle())
+                .simpleInfo(task.getSimpleInfo())
+                .startDate(task.getPeriod().getStartDate())
+                .endDate(task.getPeriod().getEndDate())
+                .subscriberCount(task.getSubscriberCount())
+                .build();
+    }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
@@ -1,6 +1,7 @@
 package com.fthon.subsclife.repository;
 
 import com.fthon.subsclife.entity.Task;
+import com.fthon.subsclife.repository.query.QueryTaskRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,7 +11,7 @@ import java.util.Optional;
 
 
 @Repository
-public interface TaskRepository extends JpaRepository<Task, Long> {
+public interface TaskRepository extends JpaRepository<Task, Long>, QueryTaskRepository {
 
     @Query("SELECT t FROM Task t LEFT JOIN FETCH t.subscribes WHERE t.id = :taskId")
     Optional<Task> findByIdWithSubscribes(@Param("taskId") Long taskId);

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/query/QueryTaskRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/query/QueryTaskRepository.java
@@ -1,0 +1,11 @@
+package com.fthon.subsclife.repository.query;
+
+import com.fthon.subsclife.dto.PagedItem;
+import com.fthon.subsclife.dto.TaskDto;
+import com.fthon.subsclife.entity.Task;
+
+
+public interface QueryTaskRepository {
+
+    PagedItem<Task> searchTaskList(TaskDto.Cursor cursor, TaskDto.SearchCondition cond);
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/query/TaskRepositoryImpl.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/query/TaskRepositoryImpl.java
@@ -1,0 +1,119 @@
+package com.fthon.subsclife.repository.query;
+
+import com.fthon.subsclife.dto.PagedItem;
+import com.fthon.subsclife.dto.TaskDto;
+import com.fthon.subsclife.entity.Task;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.fthon.subsclife.entity.QSubscribe.*;
+import static com.fthon.subsclife.entity.QTask.*;
+
+@RequiredArgsConstructor
+public class TaskRepositoryImpl implements QueryTaskRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public PagedItem<Task> searchTaskList(TaskDto.Cursor cursor, TaskDto.SearchCondition cond) {
+        List<Long> pagedTaskIds = queryFactory
+                .select(task.id)
+                .from(task)
+                .where(
+                        startFromGoe(cond.getStartFrom()),
+                        endToLoe(cond.getEndTo()),
+                        containsKeyword(cond.getKeyword()),
+                        cursorCondition(cursor.getEndDate(), cursor.getStartDate(), cursor.getTaskId())
+                )
+                .orderBy(
+                        task.period.endDate.asc(),
+                        task.period.startDate.asc(),
+                        task.id.desc()
+                )
+                .limit(cond.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if(pagedTaskIds.size() > cond.getPageSize()) {
+            pagedTaskIds.remove(pagedTaskIds.size() - 1);
+            hasNext = true;
+        }
+
+        List<Task> tasks = queryFactory
+                .selectFrom(task)
+                .leftJoin(task.subscribes, subscribe).fetchJoin()
+                .where(task.id.in(pagedTaskIds))
+                .orderBy(task.period.endDate.asc(), task.period.startDate.asc(), task.id.desc())
+                .fetch();
+
+        return new PagedItem<>(tasks, hasNext);
+    }
+
+    // 마감시간이 적게 남은 것 부터 조회하기 때문에
+    // 다음 페이지는 시간이 더 많이 남은 아이템이 되어야 함
+    private BooleanExpression endDateGt(LocalDateTime endDate) {
+        return endDate != null ? task.period.endDate.gt(endDate) : null;
+    }
+
+    private BooleanExpression endDateEq(LocalDateTime endDate) {
+        return endDate != null ? task.period.endDate.eq(endDate) : null;
+    }
+
+    // 마감시간이 동일하다면
+    // 먼저 시작할 태스크부터 조회되어야 함
+    private BooleanExpression startDateLt(LocalDateTime startDate) {
+        return startDate != null ? task.period.startDate.lt(startDate) : null;
+    }
+
+    private BooleanExpression startDateEq(LocalDateTime startDate) {
+        return startDate != null ? task.period.startDate.eq(startDate) : null;
+    }
+
+    // 시작 & 마감시간이 동일하다면
+    // 먼저 등록된 태스크부터 조회되어야 함
+    private BooleanExpression taskIdLt(Long taskId) {
+        return taskId != null ? task.id.lt(taskId) : null;
+    }
+
+    // 마감 시간이 동일할 때는
+    // 시작 시간이 빠른걸로
+    private BooleanExpression endDateEqAndStartDateLt(LocalDateTime endDate, LocalDateTime startDate) {
+        return endDateEq(endDate)
+                .and(startDateLt(startDate));
+    }
+
+    // 마감 시간이 동일하고 시작 시간이 똑같을 땐
+    // 먼저 등록된 순서대로
+    private BooleanExpression endDateEqAndStartDateEqAndIdLt(LocalDateTime endDate, LocalDateTime startDate, Long taskId) {
+        return endDateEq(endDate)
+                .and(startDateEq(startDate))
+                .and(taskIdLt(taskId));
+    }
+
+    // and() 메소드 직접 호출 시 null check 필요
+    private BooleanExpression cursorCondition(LocalDateTime endDate, LocalDateTime startDate, Long taskId) {
+        return endDate == null ? null : endDateGt(endDate)
+                .or(endDateEqAndStartDateLt(endDate, startDate))
+                .or(endDateEqAndStartDateEqAndIdLt(endDate, startDate, taskId));
+    }
+
+    // 특정 일자 이후에 시작하는 태스크를 필터링
+    private BooleanExpression startFromGoe(LocalDateTime startFrom) {
+        return startFrom != null ? task.period.startDate.goe(startFrom) : null;
+    }
+
+    // 특정 일자 이전에 마감되는 태스크를 필터링
+    private BooleanExpression endToLoe(LocalDateTime endTo) {
+        return endTo != null ? task.period.endDate.loe(endTo) : null;
+    }
+
+    // 특정 키워드를 필터링
+    private BooleanExpression containsKeyword (String keyword) {
+        return keyword != null ? task.title.contains(keyword) : null;
+    }
+
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
@@ -1,15 +1,16 @@
 package com.fthon.subsclife.service;
 
 
+import com.fthon.subsclife.dto.PagedItem;
 import com.fthon.subsclife.dto.TaskDto;
 import com.fthon.subsclife.dto.mapper.TaskMapper;
-import com.fthon.subsclife.entity.Subscribe;
 import com.fthon.subsclife.entity.Task;
 import com.fthon.subsclife.repository.TaskRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -36,6 +37,20 @@ public class TaskService {
 
         return taskMapper.toDetailResponse(task, userId);
     }
+
+    @Transactional(readOnly = true)
+    public PagedItem<TaskDto.ListResponse> getTaskList(TaskDto.Cursor cursor, TaskDto.SearchCondition cond) {
+        PagedItem<Task> pagedTasks = taskRepository.searchTaskList(cursor, cond);
+
+        List<TaskDto.ListResponse> taskListResponses = pagedTasks.getItems()
+                .stream()
+                .map(taskMapper::toListResponse)
+                .toList();
+
+        return new PagedItem<>(taskListResponses, pagedTasks.getHasNext());
+    }
+
+
 
     @Transactional(readOnly = true)
     public Task findTaskById(Long taskId) {


### PR DESCRIPTION
## #️⃣연관된 이슈
#12  TASK 조회/검색 기능

## 📝작업 내용
- `커서 기반 페이징`을 통해 페이징을 구현하였습니다.
- 태스크 시작/종료 시간 및 태스크 제목을 통한 필터링 기능을 구현하였습니다.

## 💬리뷰 요구사항
- 다음 페이지가 존재하는지 판단하기 위해 간단한 `제네릭 클래스`를 생성했습니다.
    - 기본적으로 제공되는 `Page` 혹은 `Slice` 객체는 불필요한 정보가 많다고 판단했습니다.
- 동적 쿼리 작성 시, `BooleanExpression` 내부에서 `and()` 연산 호출 시 `null check`를 직접 진행해야 합니다.