### PR TITLE
[#26] 회고(히스토리) 목록 조회 기능 구현

### DIFF
--- a/subsclife/src/main/java/com/fthon/subsclife/controller/RemindController.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/controller/RemindController.java
@@ -1,14 +1,24 @@
 package com.fthon.subsclife.controller;
 
+import com.fthon.subsclife.dto.PagedItem;
 import com.fthon.subsclife.dto.RemindDto;
-import com.fthon.subsclife.dto.mapper.RemindMapper;
-import com.fthon.subsclife.entity.Remind;
+import com.fthon.subsclife.exception.ErrorInfo;
 import com.fthon.subsclife.service.RemindService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/v1/reminds")
@@ -36,5 +46,31 @@ public class RemindController {
         }
 
 
+        @GetMapping
+        @Operation(summary = "회고 목록 조회(히스토리)", description = "회고 목록 조회 시 사용되는 API")
+        @Parameters({
+                @Parameter(name = "start_date", description = "태스크의 시작 시간"),
+                @Parameter(name = "end_date", description = "태스크의 종료 시간"),
+                @Parameter(name = "remind_id", description = "회고 ID")
+        })
+        public ResponseEntity<PagedItem<RemindDto.ListResponse>> getRemindHistory(
+                @RequestHeader("user-id") Long userId,
+                @RequestParam(name = "remind_id", required = false) Long remindId,
+                @RequestParam(name = "start_date", required = false) LocalDateTime startDate, // 태스크 시작 시간임
+                @RequestParam(name = "end_date", required = false) LocalDateTime endDate, // 태스크 종료 시간임
+                @RequestParam(name = "page_size", required = false, defaultValue = "10") Long pageSize) {
 
+                RemindDto.Cursor cursor = getCursor(remindId, startDate, endDate, pageSize);
+
+                return new ResponseEntity<>(remindService.getRemindList(cursor), HttpStatus.OK);
+        }
+
+        private static RemindDto.Cursor getCursor(Long remindId, LocalDateTime startDate, LocalDateTime endDate, Long pageSize) {
+                return RemindDto.Cursor.builder()
+                        .remindId(remindId)
+                        .startDate(startDate)
+                        .endDate(endDate)
+                        .pageSize(pageSize)
+                        .build();
+        }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/RemindDto.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/RemindDto.java
@@ -1,9 +1,12 @@
 package com.fthon.subsclife.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 public class RemindDto {
 
@@ -65,7 +68,53 @@ public class RemindDto {
     @Getter
     public static class ListResponse {
 
-        private TaskDto.DetailResponse DetailResponse;
+        private Content remindContent;
+        private TaskDto.ListResponse taskInfo;
+
+        @Builder
+        public ListResponse(Content remindContent, TaskDto.ListResponse taskInfo) {
+            this.remindContent = remindContent;
+            this.taskInfo = taskInfo;
+        }
+    }
+
+
+    @NoArgsConstructor
+    @Getter
+    public static class Content {
+
+        private Long remindId;
+        private Integer achievementRate;
+        private String achieveReason;
+        private String failReason;
+        private String improvementPlan;
+
+        @Builder
+        public Content(Long remindId, Integer achievementRate, String achieveReason, String failReason, String improvementPlan) {
+            this.remindId = remindId;
+            this.achievementRate = achievementRate;
+            this.achieveReason = achieveReason;
+            this.failReason = failReason;
+            this.improvementPlan = improvementPlan;
+        }
+    }
+
+
+    @NoArgsConstructor
+    @Getter
+    public static class Cursor {
+        private Long remindId;
+        private LocalDateTime startDate;
+        private LocalDateTime endDate;
+        private Long pageSize;
+
+        @Builder
+        public Cursor(Long remindId, LocalDateTime startDate, LocalDateTime endDate, Long pageSize) {
+            this.remindId = remindId;
+            this.startDate = startDate;
+            this.endDate = endDate;
+            this.pageSize = pageSize;
+        }
     }
 
 

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/RemindMapper.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/RemindMapper.java
@@ -1,12 +1,12 @@
 package com.fthon.subsclife.dto.mapper;
 
 import com.fthon.subsclife.dto.RemindDto;
-import com.fthon.subsclife.dto.TaskDto;
 import com.fthon.subsclife.entity.Remind;
 import com.fthon.subsclife.entity.Task;
 import com.fthon.subsclife.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
 
 @Component
 @RequiredArgsConstructor
@@ -34,6 +34,21 @@ public class RemindMapper {
                 .failReason(remind.getFailReason())
                 .improvementPlan(remind.getImprovementPlan())
                 .taskInfo(taskMapper.toListResponse(task))
+                .build();
+    }
+
+    public RemindDto.ListResponse toListResponse(Remind remind) {
+        return RemindDto.ListResponse.builder()
+                .remindContent(
+                        RemindDto.Content.builder()
+                                .remindId(remind.getId())
+                                .achievementRate(remind.getAchievementRate())
+                                .achieveReason(remind.getAchieveReason())
+                                .failReason(remind.getFailReason())
+                                .improvementPlan(remind.getImprovementPlan())
+                                .build()
+                )
+                .taskInfo(taskMapper.toListResponse(remind.getTask()))
                 .build();
     }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/RemindRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/RemindRepository.java
@@ -2,9 +2,10 @@ package com.fthon.subsclife.repository;
 
 
 import com.fthon.subsclife.entity.Remind;
+import com.fthon.subsclife.repository.query.QueryRemindRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RemindRepository extends JpaRepository<Remind, Long> {
+public interface RemindRepository extends JpaRepository<Remind, Long>, QueryRemindRepository {
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/query/QueryRemindRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/query/QueryRemindRepository.java
@@ -1,0 +1,12 @@
+package com.fthon.subsclife.repository.query;
+
+
+import com.fthon.subsclife.dto.PagedItem;
+import com.fthon.subsclife.entity.Remind;
+
+import static com.fthon.subsclife.dto.RemindDto.*;
+
+public interface QueryRemindRepository {
+
+    PagedItem<Remind> searchRemindList(Long userId, Cursor cursor);
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/query/RemindRepositoryImpl.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/query/RemindRepositoryImpl.java
@@ -1,0 +1,105 @@
+package com.fthon.subsclife.repository.query;
+
+import com.fthon.subsclife.dto.PagedItem;
+import com.fthon.subsclife.entity.Remind;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.fthon.subsclife.dto.RemindDto.*;
+import static com.fthon.subsclife.entity.QRemind.*;
+import static com.fthon.subsclife.entity.QSubscribe.*;
+import static com.fthon.subsclife.entity.QTask.*;
+
+@RequiredArgsConstructor
+public class RemindRepositoryImpl implements QueryRemindRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public PagedItem<Remind> searchRemindList(Long userId, Cursor cursor) {
+        List<Long> remindIds = queryFactory
+                .select(remind.id)
+                .from(remind)
+                .join(remind.task)
+                .join(remind.user)
+                .where(
+                        remind.user.id.eq(userId),
+                        cursorCondition(cursor.getStartDate(), cursor.getEndDate(), cursor.getRemindId())
+                )
+                .orderBy(
+                        task.period.endDate.desc(),
+                        task.period.startDate.asc(),
+                        remind.id.desc()
+                )
+                .limit(cursor.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if(remindIds.size() > cursor.getPageSize()) {
+            remindIds.remove(remindIds.size() - 1);
+            hasNext = true;
+        }
+
+        List<Remind> reminds = queryFactory
+                .selectFrom(remind)
+                .join(remind.task, task).fetchJoin()
+                .leftJoin(task.subscribes, subscribe).fetchJoin()
+                .where(remind.id.in(remindIds))
+                .orderBy(task.period.endDate.desc(), task.period.startDate.asc(), remind.id.desc())
+                .fetch();
+
+        return new PagedItem<>(reminds, hasNext);
+    }
+
+    //
+    // 마감 시간이 더 적은것을 조회
+    private BooleanExpression endDateLt(LocalDateTime endDate) {
+        return endDate != null ? task.period.endDate.lt(endDate) : null;
+    }
+
+    private BooleanExpression endDateEq(LocalDateTime endDate) {
+        return endDate != null ? task.period.endDate.eq(endDate) : null;
+    }
+
+    // 시작 시간이 더 느린 것을 조회
+    private BooleanExpression startDateGt(LocalDateTime startDate) {
+        return startDate != null ? task.period.startDate.gt(startDate) : null;
+    }
+
+    private BooleanExpression startDateEq(LocalDateTime startDate) {
+        return startDate != null ? task.period.startDate.eq(startDate) : null;
+    }
+
+    // 시작 & 마감시간이 동일하다면
+    // 나중에 작성된 회고를 먼저 조회해야 함
+    private BooleanExpression remindIdLt(Long remindId) {
+        return remindId != null ? remind.id.lt(remindId) : null;
+    }
+
+    // 시작 시간이 동일할 때는
+    // 마감 시간이 느린걸 먼저
+    private BooleanExpression endDateEqAndStartDateLt(LocalDateTime startDate, LocalDateTime endDate) {
+        return endDateEq(endDate)
+                .and(startDateGt(startDate));
+    }
+
+    // 시작 & 마감 시간이 동일할 땐
+    // 먼저 등록된 순서대로
+    private BooleanExpression endDateEqAndStartDateEqAndRemindItLt(LocalDateTime startDate, LocalDateTime endDate, Long remindId) {
+        return endDateEq(endDate)
+                .and(startDateEq(startDate))
+                .and(remindIdLt(remindId));
+    }
+
+    // and() 메소드 직접 호출 시 null check 필요
+    private BooleanExpression cursorCondition(LocalDateTime startDate, LocalDateTime endDate, Long remindId) {
+        return endDate == null ? null : endDateLt(endDate)
+                .or(endDateEqAndStartDateLt(startDate, endDate))
+                .or(endDateEqAndStartDateEqAndRemindItLt(startDate, endDate, remindId));
+    }
+
+}

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/query/TaskRepositoryImpl.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/query/TaskRepositoryImpl.java
@@ -93,7 +93,7 @@ public class TaskRepositoryImpl implements QueryTaskRepository {
 
     // 시작 & 마감 시간이 동일할 땐
     // 먼저 등록된 순서대로
-    private BooleanExpression startDateEqAndEndDateLtAndTaskIdGt(LocalDateTime startDate, LocalDateTime endDate, Long taskId) {
+    private BooleanExpression startDateEqAndEndDateEqAndTaskIdGt(LocalDateTime startDate, LocalDateTime endDate, Long taskId) {
         return startDateEq(startDate)
                 .and(endDateEq(endDate))
                 .and(taskIdGt(taskId));
@@ -103,7 +103,7 @@ public class TaskRepositoryImpl implements QueryTaskRepository {
     private BooleanExpression cursorCondition(LocalDateTime startDate, LocalDateTime endDate, Long taskId) {
         return endDate == null ? null : startDateGt(startDate)
                 .or(startDateEqAndEndDateGt(startDate, endDate))
-                .or(startDateEqAndEndDateLtAndTaskIdGt(startDate, endDate, taskId));
+                .or(startDateEqAndEndDateEqAndTaskIdGt(startDate, endDate, taskId));
     }
 
     // 특정 일자 이후에 시작하는 태스크를 필터링

--- a/subsclife/src/main/java/com/fthon/subsclife/service/RemindService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/RemindService.java
@@ -1,6 +1,6 @@
 package com.fthon.subsclife.service;
 
-import com.fthon.subsclife.dto.RemindDto;
+import com.fthon.subsclife.dto.PagedItem;
 import com.fthon.subsclife.dto.mapper.RemindMapper;
 import com.fthon.subsclife.entity.Remind;
 import com.fthon.subsclife.entity.Task;
@@ -9,7 +9,10 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+
+import static com.fthon.subsclife.dto.RemindDto.*;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +28,7 @@ public class RemindService {
 
 
     @Transactional
-    public void create(RemindDto.SaveRequest saveRequest) {
+    public void create(SaveRequest saveRequest) {
 
 
             Task task = taskService.findTaskById(saveRequest.getTaskId());
@@ -38,7 +41,7 @@ public class RemindService {
     }
 
     @Transactional(readOnly = true)
-    public RemindDto.DetailResponse getRemindDetail(Long remindId) {
+    public DetailResponse getRemindDetail(Long remindId) {
 
 
         Remind remind = remindRepository.findById(remindId)
@@ -48,9 +51,25 @@ public class RemindService {
         Task task = taskService.findTaskByIdWithSubscribes(remind.getTask().getId());
 
 
-        RemindDto.DetailResponse remindDetailResponse = remindMapper.toDetailResponse(remind, task);
+        DetailResponse remindDetailResponse = remindMapper.toDetailResponse(remind, task);
 
 
         return remindDetailResponse;
     }
+
+
+    @Transactional(readOnly = true)
+    public PagedItem<ListResponse> getRemindList(Cursor cursor) {
+        Long userId = loginService.getLoginUserId();
+
+        PagedItem<Remind> reminds = remindRepository.searchRemindList(userId, cursor);
+
+        List<ListResponse> remindList = reminds.getItems()
+                .stream()
+                .map(remindMapper::toListResponse)
+                .toList();
+
+        return new PagedItem<>(remindList, reminds.getHasNext());
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#26 회고 목록 조회 기능 구현
## 📝작업 내용
- 로그인한 사용자가 작성했던 회고를 조회하는 기능을 구현했습니다.
- 정렬은 다음과 같습니다.
    - `태스크 마감 시간` 내림차순 -> `태스크 생성 시간` 오름차순 -> `회고 작성` 내림차순