### PR TITLE
[#25] 태스크 참여 사용자 조회 시 회고 작성을 완료한 사용자 추가

### DIFF
--- a/subsclife/src/main/java/com/fthon/subsclife/repository/UserRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,4 +20,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
             " JOIN FETCH s.task" +
             " WHERE u.id = :userId")
     Optional<User> findByIdWithSubscribesAndTask(@Param("userId") Long userId);
+
+    /**
+     * 특정 태스크에 회고를 작성한 사용자 목록 반환
+     */
+    @Query("SELECT u FROM User u" +
+            " JOIN u.reminds r" +
+            " WHERE r.task.id = :taskId")
+    List<User> findUsersWhoRemindedByTaskId(@Param("taskId") Long taskId);
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/service/UserService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/UserService.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
-import java.util.function.Function;
+
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +34,11 @@ public class UserService {
     public User findUserByIdWithSubscribesAndTask(Long id) {
         return userRepository.findByIdWithSubscribesAndTask(id)
                 .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public List<User> findUserByTaskIdWhoReminded(Long taskId) {
+        return userRepository.findUsersWhoRemindedByTaskId(taskId);
     }
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#25 태스크 참여한 사용자 정보 반환 API 구현

## 📝작업 내용
- 참여자 반환 로직이 변경되었습니다.
    - 기존 ; 태스크를 구독한 사용자를 조회
    - 변경 : 태스크 구독자 + 해당 태스크에 회고를 작성한 사용자 조회