### PR TITLE
[#39] 구독이 없는 태스크가 조회되도록 쿼리 수정

### DIFF
--- a/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
@@ -18,7 +18,7 @@ public interface TaskRepository extends JpaRepository<Task, Long>, QueryTaskRepo
 
     @Query("SELECT t FROM Task t" +
             " LEFT JOIN FETCH t.subscribes s" +
-            " JOIN FETCH s.user u" +
+            " LEFT JOIN FETCH s.user u" +
             " WHERE t.id = :taskId")
     Optional<Task> findByIdWithSubscribesAndUser(@Param("taskId") Long taskId);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#39 구독자 없는 태스크 세부 조회 불가능

## 📝작업 내용
- 구독자가 존재하지 않는 태스크도 정상적으로 조회될 수 있도록 수정했습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 실행 시
![image](https://github.com/user-attachments/assets/ef132ac8-54d6-4cba-b632-52fbafae1181)