### PR TITLE
[#26] 회고 목록 조회 시 태스크 참여 인원 계산 로직 수정

### DIFF
--- a/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/RemindMapper.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/RemindMapper.java
@@ -38,7 +38,11 @@ public class RemindMapper {
                 .build();
     }
 
-    public RemindDto.ListResponse toListResponse(Remind remind) {
+
+    /**
+     * 완료된 태스크의 경우 작성된 회고도 참여자에 포함해야 함
+     */
+    public RemindDto.ListResponse toListResponse(Remind remind, Integer reminderCount) {
         return RemindDto.ListResponse.builder()
                 .remindContent(
                         RemindDto.Content.builder()
@@ -49,7 +53,7 @@ public class RemindMapper {
                                 .improvementPlan(remind.getImprovementPlan())
                                 .build()
                 )
-                .taskInfo(taskMapper.toListResponse(remind.getTask()))
+                .taskInfo(taskMapper.toListResponse(remind.getTask(), reminderCount))
                 .build();
     }
 

--- a/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/TaskMapper.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/dto/mapper/TaskMapper.java
@@ -55,6 +55,19 @@ public class TaskMapper {
                 .build();
     }
 
+
+    public TaskDto.ListResponse toListResponse(Task task, Integer reminderCount) {
+        return TaskDto.ListResponse.builder()
+                .taskId(task.getId())
+                .title(task.getTitle())
+                .simpleInfo(task.getSimpleInfo())
+                .startDate(task.getPeriod().getStartDate())
+                .endDate(task.getPeriod().getEndDate())
+                .subscriberCount(task.getSubscriberCount() + reminderCount)
+                .build();
+    }
+
+
     public TaskDto.HistoryResponse toHistoryResponse(Task task, List<RemindDto.SingleResponse> reminds) {
         return TaskDto.HistoryResponse.builder()
                 .taskId(task.getId())

--- a/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/TaskRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -28,4 +29,10 @@ public interface TaskRepository extends JpaRepository<Task, Long>, QueryTaskRepo
             " JOIN FETCH r.user u" +
             " WHERE t.id = :taskId")
     Optional<Task> findByIdWithRemindsAndUsers(@Param("taskId") Long taskId);
+
+    // 회고 목록 조회 중 태스크 참여자 수를 조회하기 위함
+    @Query("SELECT t FROM Task t" +
+            " JOIN FETCH t.reminds r" +
+            " WHERE t.id IN :taskIds")
+    List<Task> findTasksByIdsWithReminds(@Param("taskIds") List<Long> taskIds);
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/service/RemindService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/RemindService.java
@@ -82,12 +82,27 @@ public class RemindService {
 
         PagedItem<Remind> reminds = remindRepository.searchRemindList(userId, cursor);
 
+        List<Long> taskIds = reminds.getItems().stream()
+                .map(r -> r.getTask().getId())
+                .toList();
+
+        List<Task> tasks = taskService.findTasksByIdsWithReminds(taskIds);
+
         List<ListResponse> remindList = reminds.getItems()
                 .stream()
-                .map(remindMapper::toListResponse)
+                .map(r -> remindMapper.toListResponse(r, getRemindCountByTaskId(tasks, r.getTask().getId())))
                 .toList();
 
         return new PagedItem<>(remindList, reminds.getHasNext());
     }
 
+
+    private Integer getRemindCountByTaskId(List<Task> tasks, Long taskId) {
+        for (Task task : tasks) {
+            if (task.getId().equals(taskId)) {
+                return task.getReminds().size();
+            }
+        }
+        return 0;
+    }
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
@@ -17,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -122,6 +121,11 @@ public class TaskService {
     public Task findTaskByIdWithRemindsAndUser(Long taskId) {
         return taskRepository.findByIdWithRemindsAndUsers(taskId)
                 .orElseThrow(() -> new NoSuchElementException("찾으려는 태스크가 없습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Task> findTasksByIdsWithReminds(List<Long> taskIds) {
+        return taskRepository.findTasksByIdsWithReminds(taskIds);
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#26 회고 목록 조회 기능 구현

## 📝작업 내용
- 회고 목록 조회 API 내부의 태스크 참여 인원 계산 로직이 수정되었습니다.
    - 기존 : 해당 태스크의 구독자 수
    - 변경 : 해당 태스크의 구독자 수 + 해당 태스크에 작성된 회고 수