### PR TITLE
[#49] 태스크 목록 조회 시 구독한 태스크 조회되지 않도록 변경

### DIFF
--- a/subsclife/src/main/java/com/fthon/subsclife/repository/query/QueryTaskRepository.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/repository/query/QueryTaskRepository.java
@@ -7,5 +7,5 @@ import com.fthon.subsclife.entity.Task;
 
 public interface QueryTaskRepository {
 
-    PagedItem<Task> searchTaskList(TaskDto.Cursor cursor, TaskDto.SearchCondition cond);
+    PagedItem<Task> searchTaskList(TaskDto.Cursor cursor, TaskDto.SearchCondition cond, Long userId);
 }

--- a/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
+++ b/subsclife/src/main/java/com/fthon/subsclife/service/TaskService.java
@@ -76,7 +76,8 @@ public class TaskService {
 
     @Transactional(readOnly = true)
     public PagedItem<TaskDto.ListResponse> getTaskList(TaskDto.Cursor cursor, TaskDto.SearchCondition cond) {
-        PagedItem<Task> pagedTasks = taskRepository.searchTaskList(cursor, cond);
+        Long userId = loginService.getLoginUserId();
+        PagedItem<Task> pagedTasks = taskRepository.searchTaskList(cursor, cond, userId);
 
         List<TaskDto.ListResponse> taskListResponses = pagedTasks.getItems()
                 .stream()


### PR DESCRIPTION
## #️⃣연관된 이슈
#49 자신이 구독한 태스크는 보이지 않도록 변경
## 📝작업 내용
- 태스크 목록 조회 시 이미 구독한 태스크는 조회되지 않도록 변경했습니다.